### PR TITLE
fixes github link in init.rb

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -6,6 +6,6 @@ Redmine::Plugin.register :redmine_extended_spent_time do
   description 'Redmine plugin used to extend spent time visualisation options located in "my page"'
   version '0.0.2'
   requires_redmine :version_or_higher => ['1.1.0']
-  url 'https://github.com/jmvallet/redmine_extended_spent_time'
+  url 'https://github.com/Pertimm/redmine_extended_spent_time'
   author_url 'http://jmvallet.net/'
 end


### PR DESCRIPTION
Migrate from the old project location to the Pertimm group.

redmine plugins page also need to be updated:
http://www.redmine.org/plugins/extended_spent_time
