### PR TITLE
redmine_extended_spent_time also tested on Redmine 2.3.1 and 2.3.3, so ...

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -3,7 +3,7 @@ Redmine::Plugin.register :redmine_extended_spent_time do
   author 'Jean-Marie Vallet'
   description 'Redmine plugin used to extend spent time visualisation options located in "my page"'
   version '0.0.3'
-  requires_redmine :version => ['2.2.1']
+  requires_redmine :version => ['2.2.1', '2.3']
   url 'https://github.com/Pertimm/redmine_extended_spent_time'
   author_url 'http://jmvallet.net/'
 end


### PR DESCRIPTION
...it's 2.3.x compatible
