### PR TITLE
Add support of Russian langauge and newer versions of Redmine

### DIFF
--- a/app/views/my/blocks/_log.html.erb
+++ b/app/views/my/blocks/_log.html.erb
@@ -14,11 +14,11 @@ sql_period = period - 1
     <a href="#" data-period="7" class="select-link <%= 'current' if period == 7 %>">
       1 <%= l(:label_extended_spent_time_week) %></a>
     <a href="#" data-period="14" class="select-link <%= 'current' if period == 14 %>">
-      2 <%= l(:label_extended_spent_time_weeks) %></a>
+      2 <%= l(:label_extended_spent_time_weeks_paucal) %></a>
     <a href="#" data-period="21" class="select-link <%= 'current' if period == 21 %>">
-      3 <%= l(:label_extended_spent_time_weeks) %></a>
+      3 <%= l(:label_extended_spent_time_weeks_paucal) %></a>
     <a href="#" data-period="28" class="select-link <%= 'current' if period == 28 %>">
-      4 <%= l(:label_extended_spent_time_weeks) %></a>
+      4 <%= l(:label_extended_spent_time_weeks_paucal) %></a>
     <a href="#" data-period="35" class="select-link <%= 'current' if period == 35 %>">
       5 <%= l(:label_extended_spent_time_weeks) %></a>
   </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,4 +1,5 @@
 de:
   label_extended_spent_time_week: "Woche"
+  label_extended_spent_time_weeks_paucal: "Wochen"
   label_extended_spent_time_weeks: "Wochen"
   label_extended_spent_time_options: "Anzeigeoptionen:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,5 @@
 en:
   label_extended_spent_time_week: "week"
+  label_extended_spent_time_weeks_paucal: "weeks"
   label_extended_spent_time_weeks: "weeks"
   label_extended_spent_time_options: "Display options:"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,5 @@
 es:
   label_extended_spent_time_week: "semana"
-  label_extended_spent_time_weeks: "semana"
+  label_extended_spent_time_weeks_paucal: "semanas"
+  label_extended_spent_time_weeks: "semanas"
   label_extended_spent_time_options: "Ver:"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,5 @@
 fr:
   label_extended_spent_time_week: "semaine"
+  label_extended_spent_time_weeks_paucal: "semaines"
   label_extended_spent_time_weeks: "semaines"
   label_extended_spent_time_options: "Options d'affichage :"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,4 +1,5 @@
 pt:
   label_extended_spent_time_week: "semana"
+  label_extended_spent_time_weeks_paucal: "semanas"
   label_extended_spent_time_weeks: "semanas"
   label_extended_spent_time_options: "Opções de exibição:"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,4 @@
+ru:
+  label_extended_spent_time_week: "неделя"
+  label_extended_spent_time_weeks: "недель"
+  label_extended_spent_time_options: "Параметры отображения:"

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,4 +1,5 @@
 ru:
   label_extended_spent_time_week: "неделя"
+  label_extended_spent_time_weeks_paucal: "недели"
   label_extended_spent_time_weeks: "недель"
   label_extended_spent_time_options: "Параметры отображения:"

--- a/init.rb
+++ b/init.rb
@@ -3,7 +3,7 @@ Redmine::Plugin.register :redmine_extended_spent_time do
   author 'Jean-Marie Vallet'
   description 'Redmine plugin used to extend spent time visualisation options located in "my page"'
   version '0.0.3'
-  requires_redmine :version => ['2.2.1', '2.3']
+  requires_redmine :version_or_higher => '2.2.1'
   url 'https://github.com/Pertimm/redmine_extended_spent_time'
   author_url 'http://jmvallet.net/'
 end


### PR DESCRIPTION
I've tested this plugin in Redmine 2.4. It works well, so I've updated requires_redmine.

Also I've added config for Russian language. Russian (like some other Slavic langauges) has a specific paucal form for some plural nouns, including неделя ('week'). I added support of such a forms in plugin.

Paucal in Russian comes from Dual number in Ancient Russian and use used in plural Genitive case when there're 1.5, 2, 3, or 4 items. Like this:

1 week = 1 неделя
2 weeks = 2 недели
3 weeks = 3 недели
4 weeks = 4 недели
5 weeks = 5 недель
6 weeks = 6 недель
